### PR TITLE
Update gptsovits.py to avoid slow api performance

### DIFF
--- a/tts/gptsovits.py
+++ b/tts/gptsovits.py
@@ -2,6 +2,7 @@ import requests
 import time
 from utils import util
 import wave
+from gradio_client import Client
 class Speech:
 
     def connect(self):
@@ -12,27 +13,29 @@ class Speech:
        pass
 
     def to_sample(self, text, style) :    
-        url = "http://127.0.0.1:9880"
+        url = "http://127.0.0.1:9872"
         data = {
         "text": text,
         "text_language": "zh",
         "cut_punc": "，。"
     }
         try:
-            response = requests.post(url, json=data)
-            file_url = './samples/sample-' + str(int(time.time() * 1000)) + '.wav'
-            if response.status_code == 200:
-                with wave.open(file_url, 'wb') as wf:
-                        wf.setnchannels(1)
-                        wf.setsampwidth(2)
-                        wf.setframerate(16000)
-                        wf.writeframes(response.content)
-                return file_url
-            
-            else:
-                util.log(1, "[x] 语音转换失败！")
-                util.log(1, "[x] 原因: " + str(response.text))
-                return None
+            client = Client(url)
+            file_url = client.predict(
+                "/Users/leosyzhang/sourcecode/ai/aivoice/GPT-SoVITS/ReferenceWav/四爷/说话-小桂子这一身的才华，去哪儿都会被埋没.wav",
+                "小桂子这一身的才华，去哪儿都会被埋没",
+                "Chinese",
+                text,
+                "Chinese",
+                "No slice",
+                1,
+                0,
+                0,
+                True,
+                fn_index=3
+            )
+            util.log(1, file_url)
+            return file_url
         
         except Exception as e :
                 util.log(1, "[x] 语音转换失败！")


### PR DESCRIPTION
1. 原来的代码，是通过api的方式调用gptsovits，那么需要通过api的方式启动gptsovits，同时启动gptsovits的时候需要指定模型，指定参考音频，以及指定参考音频的文本和语言，以避免fay这边的代码改动，例如：
python api.py -s SoVITS_weights/四爷讲AI.pth -g GPT_weights/四爷讲AI.ckpt -dr "/Users/leosyzhang/sourcecode/ai/aivoice/GPT-SoVITS/ReferenceWav/四爷/说话-小桂子这一身的才华，去哪儿都会被埋没.wav" -dt "小桂子这一身的才华，去哪儿都会被埋没" -dl "zh"

但是实测发现通过api启动gptsovits的方式性能非常的慢。可能是因为我把所有东西都部署到一部机器上的原因
ollama + funasr + fay + gptsovits

3. 如果仅仅是个人demo，不是真正的生产部署，有一个相对比较快的办法，首先把gptsovits和fay的服务器部署在同一部机器上。 然后python webui.py的方式启动gptsovits
然后访问gptsovits的tts的界面，确保gptsovits能正常使用
![image](https://github.com/user-attachments/assets/b4a61d13-26c0-43fc-8722-d5436ce764b3)


然后在fay的环境里面pip install gradio_client，通过gradio client的方式进行tts合成，性能会快很多，因为这种方式生成的语音文件都是本地的临时文件，减少了网络调用，性能会快一点，该方式不通用，但是可以个人demo