### PR TITLE
Add TwelveLabs Pegasus video understanding MCP server (opt-in)

### DIFF
--- a/mcp_servers/twelvelabs_video/README.md
+++ b/mcp_servers/twelvelabs_video/README.md
@@ -1,0 +1,57 @@
+# TwelveLabs Pegasus 视频理解 MCP Server
+
+让 Fay 的 agent 具备"看懂视频"的能力：通过 [TwelveLabs](https://twelvelabs.io) 的
+Pegasus 视频理解模型对视频进行总结、问答、要点提取等，返回自然语言文本。
+
+提供一个工具：
+
+- `analyze_video`：对一个视频（公开 URL 或已上传的 `asset_id`）按提示词进行分析，返回文本结果。
+
+完全可选：不配置 `TWELVELABS_API_KEY` 时该服务器不会启动，对现有功能无任何影响。
+
+## 准备
+
+1. 进入本目录：`cd mcp_servers/twelvelabs_video`
+2. 安装依赖：`pip install -r requirements.txt`（需要 `mcp` 与 `twelvelabs>=1.2.8`）
+3. 申请并设置 API key（免费额度较为慷慨）：
+
+   ```bash
+   export TWELVELABS_API_KEY="你的key"   # Windows: set TWELVELABS_API_KEY=你的key
+   ```
+
+可选环境变量：
+
+- `TWELVELABS_MODEL`：模型名，默认 `pegasus1.5`。
+- `TWELVELABS_MAX_TOKENS`：默认输出 token 上限，默认 `2048`（Pegasus 1.5 最小为 512）。
+
+## 运行
+
+```bash
+python mcp_servers/twelvelabs_video/server.py
+```
+
+或在 Fay 的 MCP 管理页面添加一条记录：
+
+- transport: `stdio`
+- command: `python`
+- args: `["mcp_servers/twelvelabs_video/server.py"]`
+- env: `{"TWELVELABS_API_KEY": "你的key"}`
+- cwd: 仓库根目录或留空
+
+## 工具参数
+
+- `analyze_video`
+  - `prompt` (必填): 引导分析的提示词，例如 `用一句话总结这个视频` 或 `视频里出现了哪些物体？`。
+  - `video_url` (可选): 视频文件的直链 http(s) URL（与 `asset_id` 二选一）。
+  - `asset_id` (可选): 已上传到 TwelveLabs 的视频 asset 的 ID（与 `video_url` 二选一）。
+  - `max_tokens` (可选): 输出 token 上限，Pegasus 1.5 最小为 512，默认取 `TWELVELABS_MAX_TOKENS`。
+  - `start_time` / `end_time` (可选): 只分析视频的某个时间窗口（秒，Pegasus 1.5），窗口需 ≥ 4 秒。
+
+返回内容：模型生成的文本（总结/答案等）。
+
+## 注意事项（来自 TwelveLabs API）
+
+- Pegasus 1.5 **不接受**裸 `video_id`，只能用公开 URL 或上传后的 `asset_id`。
+- 公开 URL 视频最大约 4GB；本地文件以 asset 方式上传上限 200MB。
+- 被分析的视频/时间窗口需 ≥ 4 秒。
+- 分享链接（YouTube/网盘等）不被接受，需直链媒体文件。

--- a/mcp_servers/twelvelabs_video/requirements.txt
+++ b/mcp_servers/twelvelabs_video/requirements.txt
@@ -1,0 +1,2 @@
+mcp
+twelvelabs>=1.2.8

--- a/mcp_servers/twelvelabs_video/server.py
+++ b/mcp_servers/twelvelabs_video/server.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+TwelveLabs Pegasus 视频理解 MCP server.
+
+通过 TwelveLabs Pegasus 模型对视频进行理解/分析，让 Fay 的 agent 能够"看懂"视频内容
+（总结、问答、提取要点等），返回自然语言文本。
+
+Tools:
+- analyze_video: 对一个视频（公开 URL 或已上传的 asset_id）按给定提示词进行分析，返回文本结果。
+
+凭据：从环境变量 TWELVELABS_API_KEY 读取（绝不在代码中硬编码）。
+未配置 API key 时该服务器不会启动，因此对未配置者无任何影响（完全可选）。
+免费 API key 可在 https://twelvelabs.io 申请，有较慷慨的免费额度。
+"""
+
+import asyncio
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+try:
+    from twelvelabs import TwelveLabs
+    from twelvelabs.types import VideoContext_AssetId, VideoContext_Url
+except ImportError:
+    print(
+        "twelvelabs SDK not installed. Please run: pip install -r requirements.txt",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+try:
+    from mcp.server import Server
+    from mcp.types import Tool, TextContent
+    import mcp.server.stdio
+except ImportError:
+    print("MCP library not installed. Please run: pip install mcp", file=sys.stderr)
+    sys.exit(1)
+
+
+# 配置（全部来自环境变量，便于在 Fay 的 MCP 管理页面里配置）
+API_KEY = os.getenv("TWELVELABS_API_KEY", "").strip()
+DEFAULT_MODEL = os.getenv("TWELVELABS_MODEL", "pegasus1.5").strip() or "pegasus1.5"
+# Pegasus 1.5 要求 max_tokens 在 512~65536 之间
+DEFAULT_MAX_TOKENS = int(os.getenv("TWELVELABS_MAX_TOKENS", "2048"))
+
+if not API_KEY:
+    print(
+        "TWELVELABS_API_KEY is not set. Get a free key at https://twelvelabs.io and "
+        "configure it in the MCP server environment.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+server = Server("twelvelabs_video")
+
+_client: Optional[TwelveLabs] = None
+
+
+def _get_client() -> TwelveLabs:
+    """惰性创建 TwelveLabs 客户端，复用单例。"""
+    global _client
+    if _client is None:
+        _client = TwelveLabs(api_key=API_KEY)
+    return _client
+
+
+def _text_content(text: str):
+    try:
+        return TextContent(type="text", text=text)
+    except Exception:
+        return {"type": "text", "text": text}
+
+
+def _build_video_context(video_url: str, asset_id: str):
+    """根据传入参数构造 Pegasus 的视频输入。
+
+    注意：Pegasus 1.5 不接受裸 video_id，只能用公开 URL 或已上传的 asset_id。
+    """
+    url = (video_url or "").strip()
+    asset = (asset_id or "").strip()
+    if url and asset:
+        raise ValueError("video_url 与 asset_id 只能二选一。")
+    if url:
+        return VideoContext_Url(url=url)
+    if asset:
+        return VideoContext_AssetId(asset_id=asset)
+    raise ValueError("必须提供 video_url 或 asset_id 其中之一。")
+
+
+def analyze_video(
+    prompt: str,
+    video_url: str = "",
+    asset_id: str = "",
+    max_tokens: Optional[int] = None,
+    start_time: Optional[float] = None,
+    end_time: Optional[float] = None,
+    model_name: Optional[str] = None,
+) -> str:
+    """调用 Pegasus 分析视频并返回文本结果。"""
+    if not prompt or not str(prompt).strip():
+        raise ValueError("prompt（提示词）不能为空。")
+
+    video = _build_video_context(video_url, asset_id)
+    tokens = max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS
+    try:
+        tokens = int(tokens)
+    except Exception:
+        tokens = DEFAULT_MAX_TOKENS
+    # Pegasus 1.5 要求 max_tokens >= 512
+    tokens = max(512, tokens)
+
+    # 可选时间窗口（Pegasus 1.5），用于只分析视频的一段；窗口需 >= 4 秒。
+    kwargs: Dict[str, Any] = {}
+    if start_time is not None:
+        kwargs["start_time"] = float(start_time)
+    if end_time is not None:
+        kwargs["end_time"] = float(end_time)
+
+    client = _get_client()
+    response = client.analyze(
+        model_name=(model_name or DEFAULT_MODEL),
+        video=video,
+        prompt=str(prompt).strip(),
+        max_tokens=tokens,
+        **kwargs,
+    )
+    return getattr(response, "data", "") or ""
+
+
+TOOLS: List[Tool] = [
+    Tool(
+        name="analyze_video",
+        description=(
+            "Understand/analyse a video with TwelveLabs Pegasus and return text "
+            "(summary, Q&A, key points, etc.). Provide a public video URL or an "
+            "uploaded asset_id (a bare video_id is NOT accepted by Pegasus 1.5). "
+            "Public URLs are supported up to ~4GB; local-file uploads via asset are "
+            "capped at 200MB. The analysed window must be at least 4 seconds."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Instruction guiding the analysis, e.g. '用一句话总结这个视频' or 'What objects appear?'.",
+                },
+                "video_url": {
+                    "type": "string",
+                    "description": "Direct http(s) URL to a video file (mutually exclusive with asset_id).",
+                },
+                "asset_id": {
+                    "type": "string",
+                    "description": "ID of a video asset already uploaded to TwelveLabs (mutually exclusive with video_url).",
+                },
+                "max_tokens": {
+                    "type": "integer",
+                    "description": "Max output tokens (Pegasus 1.5 minimum 512). Defaults to TWELVELABS_MAX_TOKENS.",
+                },
+                "start_time": {
+                    "type": "number",
+                    "description": "Optional analysis window start in seconds (Pegasus 1.5). Window must be >= 4s.",
+                },
+                "end_time": {
+                    "type": "number",
+                    "description": "Optional analysis window end in seconds (Pegasus 1.5). Window must be >= 4s.",
+                },
+            },
+            "required": ["prompt"],
+        },
+    ),
+]
+
+
+@server.list_tools()
+async def list_tools() -> List[Tool]:
+    return TOOLS
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: Optional[Dict[str, Any]]) -> List[Any]:
+    args = arguments or {}
+    try:
+        if name == "analyze_video":
+            prompt = args.get("prompt", "")
+            video_url = args.get("video_url", "") or ""
+            asset_id = args.get("asset_id", "") or ""
+            max_tokens = args.get("max_tokens")
+            start_time = args.get("start_time")
+            end_time = args.get("end_time")
+            # 网络/分析为阻塞调用，放到线程里避免卡住事件循环
+            text = await asyncio.to_thread(
+                analyze_video,
+                prompt,
+                video_url,
+                asset_id,
+                max_tokens,
+                start_time,
+                end_time,
+            )
+            return [_text_content(text or "（模型未返回内容）")]
+
+        return [_text_content(f"Unknown tool: {name}")]
+
+    except Exception as exc:
+        return [_text_content(f"Error running tool {name}: {exc}")]
+
+
+async def main() -> None:
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        init_opts = server.create_initialization_options()
+        await server.run(read_stream, write_stream, init_opts)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/mcp_servers/twelvelabs_video/test_server.py
+++ b/mcp_servers/twelvelabs_video/test_server.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+TwelveLabs Pegasus 视频理解 MCP server 的轻量自检。
+
+无网络单元测试（始终运行）：校验视频输入参数构造与互斥校验。
+联网实测（仅在设置了 TWELVELABS_API_KEY 时运行）：用一个公开视频 URL 真正调用
+Pegasus，断言返回非空文本。
+
+运行：
+  python mcp_servers/twelvelabs_video/test_server.py
+"""
+
+import importlib
+import os
+import sys
+
+# server.py 在导入时要求存在 TWELVELABS_API_KEY，这里给无网络单测兜底一个占位值。
+HAS_REAL_KEY = bool(os.getenv("TWELVELABS_API_KEY", "").strip())
+if not HAS_REAL_KEY:
+    os.environ["TWELVELABS_API_KEY"] = "test-placeholder-key"
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+server = importlib.import_module("server")
+
+# 一个公开的 720p 视频（>=4s，分辨率合规），用于联网实测。
+SAMPLE_VIDEO_URL = (
+    "https://archive.org/download/BigBuckBunny_124/Content/"
+    "big_buck_bunny_720p_surround.mp4"
+)
+
+
+def test_build_video_context_url():
+    ctx = server._build_video_context("https://example.com/a.mp4", "")
+    assert ctx.url == "https://example.com/a.mp4", ctx
+
+
+def test_build_video_context_asset():
+    ctx = server._build_video_context("", "asset_123")
+    assert ctx.asset_id == "asset_123", ctx
+
+
+def test_build_video_context_requires_one_source():
+    for bad in [("", ""), ("https://x/a.mp4", "asset_1")]:
+        try:
+            server._build_video_context(*bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+def test_analyze_requires_prompt():
+    try:
+        server.analyze_video("", video_url="https://example.com/a.mp4")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for empty prompt")
+
+
+def test_live_analyze():
+    """仅在配置了真实 API key 时运行。"""
+    if not HAS_REAL_KEY:
+        print("SKIP live test (TWELVELABS_API_KEY not set)")
+        return
+    text = server.analyze_video(
+        "Describe what happens in this video in one sentence.",
+        video_url=SAMPLE_VIDEO_URL,
+        max_tokens=512,
+        start_time=0,
+        end_time=10,
+    )
+    assert isinstance(text, str) and text.strip(), repr(text)
+    print("live analyze ->", text[:160])
+
+
+if __name__ == "__main__":
+    test_build_video_context_url()
+    test_build_video_context_asset()
+    test_build_video_context_requires_one_source()
+    test_analyze_requires_prompt()
+    print("unit tests passed")
+    test_live_analyze()
+    print("OK")


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## 中文简介

本 PR 新增一个**可选的** MCP 服务器 `mcp_servers/twelvelabs_video`，让 Fay 的 agent 具备"看懂视频"的能力。

- 通过 [TwelveLabs](https://twelvelabs.io) 的 **Pegasus** 视频理解模型，对视频做总结、问答、要点提取等，返回自然语言文本。
- 暴露一个工具 `analyze_video`：输入提示词 + 公开视频 URL（或已上传的 `asset_id`），返回文本结果；并支持可选的 `start_time`/`end_time` 时间窗口。
- 凭据从环境变量 `TWELVELABS_API_KEY` 读取，**绝不硬编码**；未配置 key 时服务器不启动，**对现有功能零影响、完全可选**。
- 严格沿用本仓库现有 MCP 服务器（如 `window_capture`、`yueshen_rag`）的目录与代码约定：`server.py` + `requirements.txt` + `README.md`，stdio 传输，可在 Fay 的 MCP 管理页面直接添加。

为什么对 Fay 有用：Fay 已支持 agent 自主调用 MCP 工具，但缺少原生的视频理解能力。Pegasus 能让数字人直接理解直播/录播/教学等视频内容，是对现有多模态能力的自然补充。

> 可在 https://twelvelabs.io 免费申请 API key，有较慷慨的免费额度。

## English

This PR adds an **opt-in** MCP server at `mcp_servers/twelvelabs_video` that gives Fay's agent video-understanding via TwelveLabs **Pegasus**.

**What it adds**
- A single `analyze_video` tool: pass a prompt plus a public video URL (or an uploaded `asset_id`) and get back natural-language text (summary, Q&A, key points). Optional `start_time`/`end_time` clip windowing (Pegasus 1.5).
- Reads its key from `TWELVELABS_API_KEY` — never hardcoded. If the key is unset the server simply doesn't start, so **behaviour is unchanged for anyone not using it**.
- Mirrors the repo's existing MCP-server conventions exactly (`window_capture`, `yueshen_rag`): per-server `server.py` + `requirements.txt` + `README.md`, stdio transport, registerable from Fay's MCP management page.

**Why it helps Fay**
Fay already lets the agent call MCP tools autonomously but has no native video understanding. Pegasus lets the digital human reason over livestream/recorded/teaching video — a natural extension of the existing multimodal stack.

**How it was tested**
- No-network unit tests (input-context construction + mutual-exclusion / empty-prompt validation) pass.
- A `TWELVELABS_API_KEY`-gated live test calls Pegasus on a public sample video and asserts non-empty text — verified passing against the real API (returned a correct one-sentence description of the clip). Run: `python mcp_servers/twelvelabs_video/test_server.py`.
- `server.py` compiles and imports cleanly. The SDK contract (`twelvelabs>=1.2.8`, `analyze(model_name='pegasus1.5', video=VideoContext_Url(...), prompt=..., max_tokens=...)`) was confirmed live.

Opt-in and non-breaking. You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
